### PR TITLE
Prod 환경 배포 버그 해결

### DIFF
--- a/.github/workflows/prod_cicd.yml
+++ b/.github/workflows/prod_cicd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   cicd:


### PR DESCRIPTION
prod 환경에서 지속적으로 api 도메인이 dev 환경 도메인으로 들어가는 이슈 해결했습니다.
github secret이 제대로 설정되지 않은 것 같아 secret을 수정하고 재배포하는 시도를 했었다가, prod ci/cd workflow에 pull_request 이벤트가 빠져 있는 것을 확인해 수정했습니다.
원인은 모르겠으나 그 후 해결되었습니다......