### PR TITLE
[OD-153] recoil 폴더 내 import문 정리

### DIFF
--- a/src/recoil/Chats/AllMessages.ts
+++ b/src/recoil/Chats/AllMessages.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { chatRoomMessagesData } from '../../apis/chatting/dto';
+import type { chatRoomMessagesData } from '@apis/chatting/dto';
 
 export const AllMesagesAtom = atom<chatRoomMessagesData[] | []>({
 	key: 'allMessagesAtom',

--- a/src/recoil/Post/PostAtom.ts
+++ b/src/recoil/Post/PostAtom.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { User } from '../../apis/post/dto';
+import type { User } from '@apis/post/dto';
 
 export const postIdAtom = atom<number>({
 	key: 'postIdAtom',

--- a/src/recoil/Post/PostCommentAtom.ts
+++ b/src/recoil/Post/PostCommentAtom.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { Comment } from '../../apis/post-comment/dto';
+import type { Comment } from '@apis/post-comment/dto';
 
 export const IsCommentDeleteConfirmationModalOpenAtom = atom<boolean>({
 	key: 'isCommentDeleteConfirmationModalOpenAtom',

--- a/src/recoil/PostUpload/PostUploadAtom.ts
+++ b/src/recoil/PostUpload/PostUploadAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
-import { ClothingInfo } from '../../components/ClothingInfoItem/dto';
-import { PostImage } from '../../apis/post/dto';
+import type { ClothingInfo } from '@components/ClothingInfoItem/dto';
+import type { PostImage } from '@apis/post/dto';
 
 export const postImagesAtom = atom<PostImage[]>({
 	key: 'imagesAtom',

--- a/src/recoil/ProfileViewer/userDetailsAtom.ts
+++ b/src/recoil/ProfileViewer/userDetailsAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
-import { UserInfoData } from '../../apis/user/dto';
-import imageBasic from '../../assets/default/defaultProfile.svg';
+import type { UserInfoData } from '@apis/user/dto';
+import imageBasic from '@assets/default/defaultProfile.svg';
 
 type BasicUserInfo = Pick<UserInfoData, 'userId' | 'nickname' | 'bio' | 'isFriend' | 'profilePictureUrl'>;
 

--- a/src/recoil/util/OpponentInfo.ts
+++ b/src/recoil/util/OpponentInfo.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
-import { OtherUserDto } from '../../apis/chatting/dto';
+import type { OtherUserDto } from '@apis/chatting/dto';
 
 const { persistAtom } = recoilPersist();
 


### PR DESCRIPTION
## 주요 작업 내용

- recoil 폴더 내 import문을 지난 회의에서 정한 내용을 바탕으로 수정했습니다.

## 기타 작업 내용

- 비어 있던 /apis/chat-room 폴더를 삭제했습니다. 채팅방 관련 api는 모두 소켓(/socket/chatting)으로 처리되어 /apis/chatting 폴더에서 확인하실 수 있습니다.

## 코드 리뷰 포인트

- 없음

## 작업 화면

- 없음
